### PR TITLE
Stylen von den Ausgabebuttons

### DIFF
--- a/spion.php
+++ b/spion.php
@@ -59,9 +59,9 @@ if (isset($_POST["spieleranzahl"]) && isset($_POST["spielername0"])) {
     #Ausgabe der Wörter/Spion 
     for ($i = 0; $i < $_POST["spieleranzahl"]; $i++) {
         if($i == $spion){
-            print("<button onClick='spion()'>" . $_POST['spielername' . $i] . "</button>");
+            print("<button class ='standard' onClick='spion()'>" . $_POST['spielername' . $i] . "</button>");
         } else if ($i != $spion) {
-            print("<button onClick='nichtSpion($wort)'>" . $_POST['spielername' . $i] .  "</button>");
+            print("<button class='standard' onClick='nichtSpion($wort)' >" . $_POST['spielername' . $i] .  "</button>");
         }
     }
     print("</div");

--- a/style.css
+++ b/style.css
@@ -50,3 +50,39 @@ input[type="submit"]:hover {
     background-color: #0056aa;
 }
 
+/* Basis-Styling für Buttons */
+button {
+    padding: 10px 15px;
+    font-size: 16px;
+    border: 1px solid black;
+    border-radius: 5px;
+    cursor: pointer;
+    margin: 25px;
+  }
+  
+  /* Standard-Button-Styling */
+  button.standard {
+    background-color: #0665a4;
+    color: #fff;
+  }
+  
+  /* Hover-Effekt für alle Buttons */
+  button:hover {
+    opacity: 0.8;
+  }
+  
+  /* Hover-Effekt für Standard-Buttons */
+  button.standard:hover {
+    background-color: #2298e7;
+  }
+  
+  /* Aktiver Zustand für alle Buttons */
+  button:active {
+    transform: translateY(2px);
+  }
+  
+  /* Aktiver Zustand für Standard-Buttons */
+  button.standard:active {
+    background-color: #216a94;
+  }
+  


### PR DESCRIPTION
Die von #7 eingeführten Buttons werden jetzt beim Ausgeben mit css ordentlicher ausgeben
Es gibt eine Klasse 'standart' für buttons. Diese erweitert das styling deutlich, ansonsten werden auch alle normalen Buttons gestylt ohne Klasse.